### PR TITLE
Add login token to console in dev mode, and create email.service.tsx

### DIFF
--- a/apps/app/pages/api/auth-email.tsx
+++ b/apps/app/pages/api/auth-email.tsx
@@ -9,8 +9,6 @@ export default async function sendAuthCode(req, res) {
   }
 
   try {
-    console.log('start');
-    console.log(req.body);
     const { email: rawEmail } = JSON.parse(req.body);
     const email = rawEmail.toLowerCase();
 
@@ -21,7 +19,6 @@ export default async function sendAuthCode(req, res) {
     }
 
     const user = await sql`SELECT * FROM "user" WHERE "email" = ${email}`;
-    console.log('user', user);
 
     const userId = user.rowCount ? user.rows[0].user_id : null;
 
@@ -39,7 +36,6 @@ export default async function sendAuthCode(req, res) {
     });
 
     if (!data.data) {
-      console.log('no data');
       res.status(403).json({ error: 'Something went wrong' });
       return;
     }

--- a/apps/app/pages/api/auth-token.tsx
+++ b/apps/app/pages/api/auth-token.tsx
@@ -43,11 +43,9 @@ export default async function validateAuthToken(req, res) {
       await sql`UPDATE auth_token SET user_id = ${user.user_id} WHERE auth_token_id = ${tokenData.auth_token_id}`;
     }
 
-    // TODO: Return JWT to set client side authentication
     const secret = process.env.JWT_SECRET;
     const jwtToken = jwt.sign({ email }, secret, { expiresIn: '1h' });
     res.setHeader('Set-Cookie', `token=${jwtToken}; path=/; httpOnly`);
-    console.log('jwt', jwtToken);
 
     res.status(200).json({ message: 'ok', token: jwtToken });
   } catch (error) {

--- a/apps/app/pages/api/goals-create.tsx
+++ b/apps/app/pages/api/goals-create.tsx
@@ -1,38 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { Resend } from 'resend';
 import { sql } from '@vercel/postgres';
 import { v4 as uuidv4 } from 'uuid';
-import { getEmailApi } from '../../utility';
-
-import * as React from 'react';
-
-interface EmailTemplateProps {
-  email: string;
-  goal: string;
-  notes?: string;
-  dueDate: Date;
-  darumaDescription: string;
-}
-
-export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
-  email,
-  goal,
-  notes,
-  dueDate,
-  darumaDescription,
-}) => (
-  <div>
-    <h5>Welcome, {email}!</h5>
-    <p>You have just created a new goal!</p>
-    <p>Here are the details:</p>
-    <p>Description: {goal}</p>
-    <p>Notes: {notes}</p>
-    <p>Due Date: {new Date(dueDate).toDateString()}</p>
-    <p>Daruma: {darumaDescription}</p>
-
-    <p>Good luck!</p>
-  </div>
-);
+import { sendIndividualEmail, NewGoalTemplate } from '../../service';
 
 export const SendGoal = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -50,8 +19,6 @@ export const SendGoal = async (req: NextApiRequest, res: NextApiResponse) => {
     const darumaDescription = body.daruma;
     const darumaColor = body.color;
     const isPublic = body?.isPublic || true;
-
-    const resend = new Resend(getEmailApi(email));
 
     // if any of the required fields are missing, return 400
     if (!email || !goal || !dueDate || !darumaDescription) {
@@ -72,21 +39,25 @@ export const SendGoal = async (req: NextApiRequest, res: NextApiResponse) => {
     const userId = userIdRows.rows[0].user_id;
 
     const goalResponse =
-      // await sql`INSERT INTO goal (goal_id, user_id, created_at, archived, due_date, description, notes, is_public) VALUES (${goalUUID}, ${userId}, ${new Date().toISOString()}, false, ${dueDate}, ${goal}, ${notes}, ${isPublic}) RETURNING *`; // ERROR 'db error: ERROR: column "archived" is of type time… You will need to rewrite or cast the expression.
       await sql`INSERT INTO goal (goal_id, user_id, created_at, due_date, description, notes, is_public, daruma) VALUES (${goalUUID}, ${userId}, ${new Date().toISOString()}, ${dueDate}, ${goal}, ${notes}, ${isPublic}, ${darumaColor}) RETURNING *`;
-
-    // send email
 
     if (!goalResponse.rowCount) {
       res.status(400).json({ error: 'Error creating goal' });
       return;
     }
 
-    const data = await resend.emails.send({
-      from: 'DarumaBoard <onboarding@resend.dev>',
-      to: [email],
-      subject: 'New Goal Created!',
-      react: EmailTemplate({ email, goal, notes, dueDate, darumaDescription }),
+    // send email
+    const data = await sendIndividualEmail({
+      email,
+      substitutions: {
+        email,
+        goal,
+        notes,
+        dueDate,
+        darumaDescription,
+      },
+      template: NewGoalTemplate,
+      subject: 'New Goal Created',
     });
 
     res.status(200).json(data);

--- a/apps/app/pages/api/goals-create.tsx
+++ b/apps/app/pages/api/goals-create.tsx
@@ -60,6 +60,11 @@ export const SendGoal = async (req: NextApiRequest, res: NextApiResponse) => {
       subject: 'New Goal Created',
     });
 
+    if (!data.data) {
+      res.status(403).json({ error: 'Something went wrong' });
+      return;
+    }
+
     res.status(200).json(data);
   } catch (error) {
     res.status(400).json({ error: error.message });

--- a/apps/app/service/email.service.tsx
+++ b/apps/app/service/email.service.tsx
@@ -63,7 +63,22 @@ export const sendIndividualEmail = async ({
   template,
   subject,
 }: EmailDetails) => {
-  const resend = new Resend(getEmailApi(email));
+  const __DEV__ = process.env.NODE_ENV === 'development';
+
+  const apiKey = getEmailApi(email);
+
+  if (!apiKey) {
+    return { error: 'No API key found for email' };
+  }
+  const resend = new Resend(apiKey);
+
+  if (__DEV__) {
+    console.log(`*** DEV MODE ***`);
+    console.log('Sending email to:', email);
+    console.log('Subject:', subject);
+    console.log('Substitutions:', substitutions);
+    return { data: 'success: email not sent in dev mode' };
+  }
 
   const data = await resend.emails.send({
     from: 'DarumaBoard <onboarding@resend.dev>', // TODO - Validate domain and have this be called from db || env

--- a/apps/app/service/email.service.tsx
+++ b/apps/app/service/email.service.tsx
@@ -1,0 +1,76 @@
+import { getEmailApi } from '../utility/getEmailApi';
+import { Resend } from 'resend';
+
+// TODO - Modularize Components into shared library
+// Email Templates
+
+interface AuthTokenSubstitutions {
+  token: number;
+}
+
+export const AuthTokenTemplate = ({ token }: AuthTokenSubstitutions) => {
+  return (
+    <div>
+      <h1>Here is your login code!</h1>
+      <p>{token}</p>
+      <p>This code will expire in 5 minutes.</p>
+    </div>
+  );
+};
+
+interface NewGoalSubstitutions {
+  email: string;
+  goal: string;
+  notes?: string;
+  dueDate: Date;
+  darumaDescription: string;
+}
+
+export const NewGoalTemplate = ({
+  email,
+  goal,
+  notes,
+  dueDate,
+  darumaDescription,
+}: NewGoalSubstitutions) => {
+  return (
+    <div>
+      <h5>Welcome, {email}!</h5>
+      <p>You have just created a new goal!</p>
+      <p>Here are the details:</p>
+      <p>Description: {goal}</p>
+      <p>Notes: {notes}</p>
+      <p>Due Date: {new Date(dueDate).toDateString()}</p>
+      <p>Daruma: {darumaDescription}</p>
+
+      <p>Good luck!</p>
+    </div>
+  );
+};
+
+// Email Service
+
+interface EmailDetails {
+  email: string;
+  subject: string;
+  substitutions: AuthTokenSubstitutions | NewGoalSubstitutions;
+  template: React.FC<Readonly<AuthTokenSubstitutions | NewGoalSubstitutions>>; // TODO: Make this and substitutions be the same enum
+}
+
+export const sendIndividualEmail = async ({
+  email,
+  substitutions,
+  template,
+  subject,
+}: EmailDetails) => {
+  const resend = new Resend(getEmailApi(email));
+
+  const data = await resend.emails.send({
+    from: 'DarumaBoard <onboarding@resend.dev>', // TODO - Validate domain and have this be called from db || env
+    to: [email],
+    subject,
+    react: template(substitutions),
+  });
+
+  return data;
+};

--- a/apps/app/service/email.service.tsx
+++ b/apps/app/service/email.service.tsx
@@ -1,6 +1,8 @@
 import { getEmailApi } from '../utility/getEmailApi';
 import { Resend } from 'resend';
 
+const OVERRIDE_EMAIL_BYPASS = false; // THIS IS FOR TESTING ONLY, DO NOT COMMIT WITH THIS SET TO TRUE, ONLY SET TO TRUE LOCALLY FOR TESTING EMAILS
+
 // TODO - Modularize Components into shared library
 // Email Templates
 
@@ -63,7 +65,8 @@ export const sendIndividualEmail = async ({
   template,
   subject,
 }: EmailDetails) => {
-  const __DEV__ = process.env.NODE_ENV === 'development';
+  const __DEV__ =
+    process.env.NODE_ENV === 'development' || OVERRIDE_EMAIL_BYPASS;
 
   const apiKey = getEmailApi(email);
 

--- a/apps/app/service/index.ts
+++ b/apps/app/service/index.ts
@@ -1,0 +1,1 @@
+export * from './email.service'

--- a/apps/app/utility/getEmailApi.ts
+++ b/apps/app/utility/getEmailApi.ts
@@ -9,6 +9,8 @@ export const getEmailApi = (email: string) => {
   const emails = RESEND_DEV_KEYS.map((item) => item[0]);
   if (emails.includes(email)) {
     return RESEND_DEV_KEYS[emails.indexOf(email)][1];
+  } else {
+    return null; // TODO - Remove else case when sender email is validated and api key is added to env that can support outside dev mode
   }
-  return process.env.RESEND_API_KEY;
+  return process.env.RESEND_API_KEY; // TODO - Remove when sender email is validated and api key is added to env that can support outside dev mode
 };


### PR DESCRIPTION
In this pull request we solve the issue of not wanting to overuse sending emails to run out of tokens, as well as rebuilding the email service every time we want to send a new email. We create the file email.service.tsx (the .service is just a label us as developers use to say what certain files are for)

For the tokens for login, when developing locally instead of getting an email, in your api log, which will appear like this:
<img width="423" alt="Screenshot 2023-12-03 at 1 36 22 PM" src="https://github.com/aram-devdocs/daruma-board/assets/59990765/c3aa6715-53cd-4a0b-bada-359b3ce0501a">

Using this info you can log in without worry of overusing your tokens.

If you are testing emails specifically, you can change `const OVERRIDE_EMAIL_BYPASS = false` to true, but be sure to not commit this change. 


For every  email, we create a template component and an interface type for the substitutions that have to be passed when sending that type of email, and update the sendIndividualEmail method accordingly. 

Left several todos to increate modularity by moving the email service to it's own library in the data access layer, which will come after further integration of the type generation system so we can update emails automatically in this process, custom tools will need to be built to support this. 