### PR TITLE
Extend token validation and expiration renewal

### DIFF
--- a/apps/app/pages/_app.tsx
+++ b/apps/app/pages/_app.tsx
@@ -40,10 +40,13 @@ const MyApp: React.FunctionComponent<MyAppProps> = (props) => {
         method: 'POST',
         body: JSON.stringify({ token }),
       })
-        .then((res) => {
+        .then(async (res) => {
           console.log(res);
+          const body = await res.json();
+
           if (res.status === 200) {
             setLoading(false);
+            localStorage.setItem('token', body.token);
           } else {
             router.push('/login');
             setLoading(false);

--- a/apps/app/pages/api/auth-token.tsx
+++ b/apps/app/pages/api/auth-token.tsx
@@ -45,7 +45,7 @@ export default async function validateAuthToken(req, res) {
 
     // TODO: Return JWT to set client side authentication
     const secret = process.env.JWT_SECRET;
-    const jwtToken = jwt.sign({ email }, secret, { expiresIn: '1h' });
+    const jwtToken = jwt.sign({ email }, secret, { expiresIn: '6h' });
     res.setHeader('Set-Cookie', `token=${jwtToken}; path=/; httpOnly`);
     console.log('jwt', jwtToken);
 


### PR DESCRIPTION
extend expiration to 6 hours, revalidate token if logged in and active if token expires in less than one hour. 